### PR TITLE
handling negative indices properly in TSC painting now

### DIFF
--- a/pmesh/tsc.py
+++ b/pmesh/tsc.py
@@ -75,7 +75,7 @@ def paint_some(pos, mesh, meshflat, weights, period):
             kernel = 1.0
             ind = 0
             for d in range(Ndim):
-                intpos = int(pos[i, d] + 0.5) # NGP index
+                intpos = numpy.rint(pos[i, d]) # NGP index
                 diff = intpos - pos[i, d]
                 rel = (n // 3**d) % 3 - 1 # maps offset (rel. to NGP) to (-1, 0, 1)
                 targetpos = intpos + rel - 1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extensions = [
         ]
 
 setup(
-    name="pmesh", version="0.0.8",
+    name="pmesh", version="0.0.9",
     author="Yu Feng",
     description="Particle Mesh in Python",
     package_dir = {'pmesh': 'pmesh'},


### PR DESCRIPTION

int(x + 0.5) only rounds to nearest integer for positive numbers --> use numpy.rint 