### PR TITLE
missing MPI import

### DIFF
--- a/pmesh/pm.py
+++ b/pmesh/pm.py
@@ -409,6 +409,7 @@ class ParticleMesh(object):
         # while not relying on pfft's full mpi4py compatibility
         # (passing None through to pfft)
         if comm is None:
+            from mpi4py import MPI
             self.comm = MPI.COMM_WORLD
         else:
             self.comm = comm


### PR DESCRIPTION
@rainwoodman  are you trying to hide the MPI import in pm.py? I did a local import if this is the case. This seems to be the only place you need it