### PR TITLE
Enhance the speed of whitenoise;

### DIFF
--- a/pmesh/_whitenoise_generics.h
+++ b/pmesh/_whitenoise_generics.h
@@ -40,10 +40,18 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
 
     int signs[3];
 
-    /* do negative then positive. ordering is import to makesure the positive overwrites nyquist. */
-    signs[0] = 1;
-    signs[1] = 0;
-    signs[2] = 0;
+    if (self->size[2] == self->Nmesh[2] / 2 + 1 && self->start[0] == 0) {
+        /* only half of the fourier space is requested, ignore the conjugates */
+        signs[0] = 1;
+        signs[1] = 0;
+        signs[2] = 0;
+    } else {
+        /* full fourier space field is requested */
+        /* do negative then positive. ordering is import to makesure the positive overwrites nyquist. */
+        signs[0] = -1;
+        signs[1] = 1;
+        signs[2] = 0;
+    }
 
     gsl_rng * rng = gsl_rng_alloc(gsl_rng_ranlxd1);
     gsl_rng_set(rng, seed);
@@ -141,11 +149,13 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
                     }
 
                     /* we want two numbers that are of std ~ 1/sqrt(2) */
-                    ampl = sqrt(- log(ampl));
-
-                    /* Unitary gaussian, the norm of real and imag is fixed to 1/sqrt(2) */
-                    if(self->unitary)
+                    if(self->unitary) {
+                        /* Unitary gaussian, the norm of real and imag is fixed to 1/sqrt(2) */
                         ampl = 1.0;
+                    } else {
+                        /* box-mueller */
+                        ampl = sqrt(- log(ampl));
+                    }
 
                     FLOAT re = ampl * cos(phase);
                     FLOAT im = ampl * sin(phase);

--- a/pmesh/_whitenoise_generics.h
+++ b/pmesh/_whitenoise_generics.h
@@ -40,6 +40,7 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
 
     int signs[3];
 
+    printf("size = %td Nmesh = %td\n", self->size[2], self->Nmesh[2]);
     if (self->size[2] == self->Nmesh[2] / 2 + 1 && self->start[2] == 0) {
         /* only half of the fourier space is requested, ignore the conjugates */
         signs[0] = 1;

--- a/pmesh/_whitenoise_generics.h
+++ b/pmesh/_whitenoise_generics.h
@@ -72,6 +72,8 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
     cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
     printf("time used in seeds = %g\n", cpu_time_used);
 
+    start = end;
+
     for(i = self->start[0];
         i < self->start[0] + self->size[0];
         i ++) {
@@ -187,6 +189,9 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
         gsl_rng_free(lower_rng);
         gsl_rng_free(this_rng);
     }
+    end = clock();
+    cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
+    printf("time used in fill = %g\n", cpu_time_used);
 }
 
 /* Footnotes */ 

--- a/pmesh/_whitenoise_generics.h
+++ b/pmesh/_whitenoise_generics.h
@@ -29,6 +29,12 @@ mkname(_set_mode)(PMeshWhiteNoiseGenerator * self, ptrdiff_t * iabs, char * delt
 static void
 mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
 {
+
+    clock_t start, end;
+    double cpu_time_used;
+
+    start = clock();
+
     /* Fill delta_k with gadget scheme */
     int i, j, k;
 
@@ -61,6 +67,10 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
             SETSEED(self, self->Nmesh[1] - 1 - j, self->Nmesh[0] - 1 - i, rng);
     }
     gsl_rng_free(rng);
+
+    end = clock();
+    cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
+    printf("time used in seeds = %g\n", cpu_time_used);
 
     for(i = self->start[0];
         i < self->start[0] + self->size[0];

--- a/pmesh/_whitenoise_generics.h
+++ b/pmesh/_whitenoise_generics.h
@@ -97,6 +97,8 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
     printf("time used in seeds = %g\n", cpu_time_used);
 
     start = end;
+    ptrdiff_t skipped = 0;
+    ptrdiff_t used = 0;
 
     for(i = self->start[0];
         i < self->start[0] + self->size[0];
@@ -161,7 +163,10 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
 
                     /* mode is not there, skip it */
                     if(!mkname(_has_mode)(self, iabs)) {
+                        skipped ++;
                         continue;
+                    } else {
+                        used ++;
                     }
 
                     /* we want two numbers that are of std ~ 1/sqrt(2) */
@@ -218,6 +223,7 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
     end = clock();
     cpu_time_used = ((double) (end - start)) / CLOCKS_PER_SEC;
     printf("time used in fill = %g\n", cpu_time_used);
+    printf("skipped = %td used = %td\n", skipped, used);
 }
 
 /* Footnotes */ 

--- a/pmesh/_whitenoise_generics.h
+++ b/pmesh/_whitenoise_generics.h
@@ -40,7 +40,7 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
 
     int signs[3];
 
-    if (self->size[2] == self->Nmesh[2] / 2 + 1 && self->start[0] == 0) {
+    if (self->size[2] == self->Nmesh[2] / 2 + 1 && self->start[2] == 0) {
         /* only half of the fourier space is requested, ignore the conjugates */
         signs[0] = 1;
         signs[1] = 0;

--- a/pmesh/_whitenoise_generics.h
+++ b/pmesh/_whitenoise_generics.h
@@ -41,8 +41,8 @@ mkname(_generic_fill)(PMeshWhiteNoiseGenerator * self, void * delta_k, int seed)
     int signs[3];
 
     /* do negative then positive. ordering is import to makesure the positive overwrites nyquist. */
-    signs[0] = -1;
-    signs[1] = 1;
+    signs[0] = 1;
+    signs[1] = 0;
     signs[2] = 0;
 
     gsl_rng * rng = gsl_rng_alloc(gsl_rng_ranlxd1);

--- a/pmesh/_whitenoise_imp.c
+++ b/pmesh/_whitenoise_imp.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <math.h>
+#include <time.h>
 
 #include <gsl/config.h>
 #include <gsl/gsl_rng.h>

--- a/pmesh/pm.py
+++ b/pmesh/pm.py
@@ -1087,7 +1087,8 @@ class ParticleMesh(object):
         self.partition = pfft.Partition(forward,
             self.Nmesh,
             self.procmesh,
-            pfft.Flags.PFFT_TRANSPOSED_OUT | paddedflag)
+           # pfft.Flags.PFFT_TRANSPOSED_OUT
+            paddedflag)
 
         bufferin = pfft.LocalBuffer(self.partition)
         bufferout = pfft.LocalBuffer(self.partition)
@@ -1106,17 +1107,25 @@ class ParticleMesh(object):
         else:
             self.forward = pfft.Plan(self.partition, pfft.Direction.PFFT_FORWARD,
                     bufferin, bufferout, forward,
-                    plan_method | pfft.Flags.PFFT_TRANSPOSED_OUT | paddedflag)
+                    plan_method
+                   # | pfft.Flags.PFFT_TRANSPOSED_OUT 
+                    | paddedflag)
             self.backward = pfft.Plan(self.partition, pfft.Direction.PFFT_BACKWARD,
                     bufferout, bufferin, backward,
-                    plan_method | pfft.Flags.PFFT_TRANSPOSED_IN | paddedflag)
+                    plan_method 
+                   # | pfft.Flags.PFFT_TRANSPOSED_IN 
+                    | paddedflag)
 
             self.ipforward = pfft.Plan(self.partition, pfft.Direction.PFFT_FORWARD,
                     bufferin, bufferin, forward,
-                    plan_method | pfft.Flags.PFFT_TRANSPOSED_OUT | paddedflag)
+                    plan_method 
+                   # | pfft.Flags.PFFT_TRANSPOSED_OUT 
+                    | paddedflag)
             self.ipbackward = pfft.Plan(self.partition, pfft.Direction.PFFT_BACKWARD,
                     bufferout, bufferout, backward,
-                    plan_method | pfft.Flags.PFFT_TRANSPOSED_IN | paddedflag)
+                    plan_method
+                   # | pfft.Flags.PFFT_TRANSPOSED_IN
+                    | paddedflag)
 
         self.domain = domain.GridND(self.partition.i_edges, comm=self.comm)
 

--- a/pmesh/pm.py
+++ b/pmesh/pm.py
@@ -7,7 +7,7 @@ from mpi4py import MPI
 
 import numbers # for testing Numbers
 import warnings
-
+import functools
 def is_inplace(out):
     return out is Ellipsis
 
@@ -412,7 +412,7 @@ class Field(object):
 
         # ensure the down sample is real
         for i, slab in zip(complex.slabs.i, complex.slabs):
-            mask = numpy.bitwise_and.reduce(
+            mask = functools.reduce(numpy.bitwise_and,
                  [(n - ii) % n == ii
                     for ii, n in zip(i, complex.Nmesh)])
             slab.imag[mask] = 0
@@ -420,13 +420,13 @@ class Field(object):
             # remove the nyquist of the output
             # FIXME: the nyquist is messy due to hermitian constraints
             # let's do not touch them till we know they are important.
-            mask = numpy.bitwise_or.reduce(
+            mask = functools.reduce(numpy.bitwise_or,
                  [ ii == n // 2
                    for ii, n in zip(i, complex.Nmesh)])
             slab[mask] = 0
 
             # also remove the nyquist of the input
-            mask = numpy.bitwise_or.reduce(
+            mask = functools.reduce(numpy.bitwise_or,
                  [ ii == n // 2
                    for ii, n in zip(i, self.Nmesh)])
             slab[mask] = 0
@@ -1280,7 +1280,7 @@ class ParticleMesh(object):
 
         # add mean
         def filter(k, v):
-            mask = numpy.bitwise_and.reduce([ki == 0 for ki in k])
+            mask = functools.reduce(numpy.bitwise_and, [ki == 0 for ki in k])
             v[mask] = mean
             return v
 

--- a/pmesh/tests/test_pm.py
+++ b/pmesh/tests/test_pm.py
@@ -85,6 +85,28 @@ def test_fft(comm):
     assert_almost_equal(numpy.asarray(real), numpy.asarray(real2), decimal=7)
 
 @MPITest(commsize=(1,4))
+def test_whitenoise_untransposed(comm):
+    pm_ut = ParticleMesh(BoxSize=8.0, Nmesh=[4, 4], comm=comm, dtype='f4', transposed=False)
+    pm_t = ParticleMesh(BoxSize=8.0, Nmesh=[4, 4], comm=comm, dtype='f4', transposed=True)
+
+    f1 = pm_ut.generate_whitenoise(seed=3333, mode='complex')
+    f2 = pm_t.generate_whitenoise(seed=3333, mode='complex')
+
+    f1r = numpy.concatenate(comm.allgather(numpy.array(f1.ravel())))
+    f2r = numpy.concatenate(comm.allgather(numpy.array(f2.ravel())))
+
+    assert_array_equal(f1r, f2r)
+
+    # this should have asserted r2c transforms as well.
+    r1 = pm_ut.generate_whitenoise(seed=3333, mode='real')
+    r2 = pm_t.generate_whitenoise(seed=3333, mode='real')
+
+    r1r = numpy.concatenate(comm.allgather(numpy.array(r1.ravel())))
+    r2r = numpy.concatenate(comm.allgather(numpy.array(r2.ravel())))
+
+    assert_array_equal(r1r, r2r)
+
+@MPITest(commsize=(1,4))
 def test_inplace_fft(comm):
     pm = ParticleMesh(BoxSize=8.0, Nmesh=[8, 8], comm=comm, dtype='f8')
     real = RealField(pm)


### PR DESCRIPTION

- skips the negative portion of the modes if not requested

- adds support non-transposed transforms, which are very efficient for the whitenoise module in 3d, due to continuity in the z axis.

Some clean up is needed before this goes into master. A few printf lines in _whitenoise_generics.h