### PR TITLE
Add particlemesh alias

### DIFF
--- a/pmesh/__init__.py
+++ b/pmesh/__init__.py
@@ -1,1 +1,2 @@
 from .version import __version__
+from .pm import ParticleMesh


### PR DESCRIPTION
Adding the top level alias to avoid name conflicts for 'only-import-module' codestyle.
ParticleMesh is the only public interface defined by the pm module, and pm is a good candidate for `pm = ParticleMesh()`.