### PR TITLE
Enhancedments of layout.exchange for hPF-MD

### DIFF
--- a/pmesh/tests/test_domain.py
+++ b/pmesh/tests/test_domain.py
@@ -41,6 +41,9 @@ def test_extra_ranks(comm):
         mass = []
 
     layout = dcop.decompose(pos, smoothing=0)
+    assert_array_equal(layout.get_exchange_cost(),
+        [2, 0, 0, 0])
+
     sendcounts = comm.allgather(layout.sendcounts)
     npos = layout.exchange(pos)
     npos = comm.allgather(npos)

--- a/pmesh/tests/test_domain.py
+++ b/pmesh/tests/test_domain.py
@@ -135,7 +135,7 @@ def test_inhomotypes(comm):
     assert_array_equal(npos[1], [[1, 0], [1, 1]])
 
     nmass = layout.exchange(mass)
-    assert nmass.dtype == numpy.dtype('complex128')
+    assert nmass.dtype == numpy.dtype('complex64')
     nmass = comm.allgather(nmass)
     assert_array_equal(nmass[0], [0, 1])
     assert_array_equal(nmass[1], [2, 3])

--- a/pmesh/tests/test_domain.py
+++ b/pmesh/tests/test_domain.py
@@ -140,6 +140,45 @@ def test_inhomotypes(comm):
     assert_array_equal(nmass[0], [0, 1])
     assert_array_equal(nmass[1], [2, 3])
 
+@MPITest(commsize=2)
+def test_packed(comm):
+    """ Testing type promotion of a packed exchange."""
+    DomainGrid = [[0, 1, 2], [0, 2]]
+
+    dcop = domain.GridND(DomainGrid, 
+            comm=comm,
+            periodic=True)
+
+    if comm.rank == 0:
+        pos = numpy.array(list(numpy.ndindex((2, 2))), dtype='f8')
+        mass = numpy.array([0, 1, 2, 3], dtype='complex64')
+    else:
+        pos = numpy.empty((0, 2), dtype='f4')
+        mass = numpy.array([], dtype='f8')
+
+    layout = dcop.decompose(pos, smoothing=0)
+    sendcounts = comm.allgather(layout.sendcounts)
+
+    nposu, nmassu = layout.exchange(pos, mass, pack=False)
+    assert nposu.dtype == numpy.dtype('f8')
+    assert nmassu.dtype == numpy.dtype('complex64')
+
+    npos, nmass = layout.exchange(pos, mass, pack=True)
+    assert npos.dtype == numpy.dtype('f8')
+    assert nmass.dtype == numpy.dtype('complex64')
+
+    assert_array_equal(npos, nposu)
+    assert_array_equal(nmass, nmassu)
+
+    npos = comm.allgather(npos)
+    nmass = comm.allgather(nmass)
+    assert_array_equal(npos[0], [[0, 0], [0, 1]])
+    assert_array_equal(npos[1], [[1, 0], [1, 1]])
+    assert_array_equal(nmass[0], [0, 1])
+    assert_array_equal(nmass[1], [2, 3])
+
+
+
 @MPITest(commsize=3)
 def test_period_empty_ranks(comm):
     DomainGrid = [[0, 2, 4, 4], [0, 4]]


### PR DESCRIPTION
- [x] instead of inferring a common data type, exchange now follows the data type of the root rank. This eliminates several
  calls to allgather, which appears to be slow on the Oslo super computer.
- [x] exchange(data1, data2, ...pack=True) for packing data before exchange. Uses more local memory but reduces  alltoallv overhead, which appears to be high on the Oslo super computer.
- [x] add a function for measuring exchange cost in hPF-MD

@sigbjobo